### PR TITLE
Options configuration fail fast with helpful error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,10 @@ module.exports = function (args) {
       ImportDeclaration(path, state) {
         const t = args.types
         const givenPath = path.node.source.value
+        
+        if (!Array.isArray(state.opts)) {
+          throw new Error('Options is required and must be an Array of Objects');
+        }
 
         state.opts.forEach((opt) => {
           const pattern = opt.pattern


### PR DESCRIPTION
Babel plugin configuration is confusing, as each plugin can define its own options signature. Throwing specific and helpful errors when this plugin is incorrectly configured helps to make it easier to use the plugin.