### PR TITLE
Include license field on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "babel-plugin-mock-imports",
   "version": "1.0.0",
   "description": "Babel Plugin to mock import statements",
+  "license" : "MIT",
   "main": "lib/index.js",
   "repository": "teod/babel-plugin-mock-imports",
   "author": "Teo Druta <teodruta@gmail.com.com>",


### PR DESCRIPTION
@teod this is a simple change to just include the license type field in the `package.json` file itself.
It would allow to check license tasks to succeed.